### PR TITLE
[#139278341] Fix the refreshToken expiration possibility

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	}()
 	go func() {
 		for {
-			err := metricProcessor(c, msgChan, errorChan)
+			err := metricProcessor(c, *updateFrequency, msgChan, errorChan)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(-1)
@@ -137,7 +137,7 @@ func updateApps(client *cfclient.Client, watchedApps map[string]*consumer.Consum
 	return nil
 }
 
-func metricProcessor(c *cfclient.Config, msgChan chan *metrics.Stream, errorChan chan error) error {
+func metricProcessor(c *cfclient.Config, updateFrequency int64, msgChan chan *metrics.Stream, errorChan chan error) error {
 	var newClient bool
 	apps := make(map[string]*consumer.Consumer)
 
@@ -158,7 +158,7 @@ func metricProcessor(c *cfclient.Config, msgChan chan *metrics.Stream, errorChan
 				return err
 			}
 
-			time.Sleep(time.Duration(*updateFrequency) * time.Second)
+			time.Sleep(time.Duration(updateFrequency) * time.Second)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Main", func() {
 			})
 
 			It("should not start any watchers", func() {
-				Expect(updateApps(client, watchers, msgChan, errChan)).To(Succeed())
+				Expect(updateApps(client, watchers, msgChan, errChan, false)).To(Succeed())
 				Expect(watchers).To(BeEmpty())
 				Consistently(msgChan).Should(BeEmpty())
 				Expect(tcServer.ReceivedRequests()).To(HaveLen(0))
@@ -131,7 +131,7 @@ var _ = Describe("Main", func() {
 			})
 
 			It("should start three watchers and disconnect when requested", func() {
-				Expect(updateApps(client, watchers, msgChan, errChan)).To(Succeed())
+				Expect(updateApps(client, watchers, msgChan, errChan, false)).To(Succeed())
 
 				var event *metrics.Stream
 
@@ -186,12 +186,12 @@ var _ = Describe("Main", func() {
 			})
 
 			It("should stop two old watchers and start two new watchers", func() {
-				Expect(updateApps(client, watchers, msgChan, errChan)).To(Succeed())
+				Expect(updateApps(client, watchers, msgChan, errChan, false)).To(Succeed())
 				for i := 0; i < len(appsBefore); i++ {
 					Eventually(msgChan).Should(Receive())
 				}
 
-				Expect(updateApps(client, watchers, msgChan, errChan)).To(Succeed())
+				Expect(updateApps(client, watchers, msgChan, errChan, false)).To(Succeed())
 
 				stoppedApps := appsBefore[:2]
 				newApps := apps[1:]


### PR DESCRIPTION
## What

As a quick followup to #1, where we've established the refreshToken could expire causing the application to fallout and not log anything, we're implementing more loops to take care of possibility of failing authentication with UAA.

It covers the updating of each running consumer, whenever it's a new client initialisation.

## How to review

- Review the code
- Create yourself an auditor user with UAA
- Either `cf push` or run application locally
  - Before hand, run the following commands [1]
  - Follow the configuration guide in the README
- _Make sure_ to run for ~10 minutes
- _Make sure_ to customise the metric template to test that functionality
- _Make sure_ to create a HostedGraphite trial account and provide the details to the application to test if sending the metrics work - This may take a while to initialise new metrics

[1]: **Configure the UAA expiration dates**

```
$ uaac target "https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital" --skip-ssl-validation
$ uaac token client get admin -s $(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-secrets.yml" -  | awk '/uaa_admin_client_secret/ {print $2}')
$ uaac client update cf --access_token_validity 3 --refresh_token_validity 6
```

## Who can review

Not @combor @keymon or @paroxp