### PR TITLE
Speed up app querying & remove ability to hit CC race condition

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	"net/url"
 	"fmt"
 	"os"
 	"strings"
@@ -130,7 +131,8 @@ func (m *metricProcessor) updateApps() error {
 		return err
 	}
 
-	apps, err := m.cfClient.ListApps()
+	q := url.Values{}
+	apps, err := m.cfClient.ListAppsByQuery(q)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What

The [existing .ListApps() query](https://github.com/cloudfoundry-community/go-cfclient/blob/master/apps.go#L217) has `inline-relations-depth` set to `2`, which causes it to recurse twice into each listed relation and fetch more information to be included in the response.

This query is very expensive (especially on large orgs) and due to the runtime it seems to be especially prone to hitting race conditions with apps being added and removed while the query is running, which causes API errors to be generated by the cloud controller.

We only actually need the GUIDs for the returned applications, so by switching to .ListAppsByQuery() and not setting `inline-relations-depth` we will no longer recurse on the server side and due to transaction isolation should no longer hit the race condition.

The querytime is reduced to around ~2s, down from ~10-20s. Hopefully this should also reduce the load on the cloud controller.

@combor Also pointed out that `inline-relations-depth` has been deprecated since CC 1.9, so we should try and submit an upstream PR to remove it. This may prove tricky as simply removing the relations will lose some data from the response and be a breaking change, and querying per-app will be too expensive.

# How to review

Code review should be ok, but you should really build and run the app to check it still works.