### PR TITLE
Fix empty space and org names and only process ContainerMetric events

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,8 +168,9 @@ func (m *metricProcessor) updateApps() error {
 			go func(currentApp cfclient.App) {
 				for message := range msg {
 					stream := metrics.Stream{Msg: message, App: currentApp, Tmpl: *metricTemplate}
-
-					m.msgChan <- &stream
+					if (*message.EventType == events.Envelope_ContainerMetric) {
+						m.msgChan <- &stream
+					}
 				}
 			}(app)
 

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"crypto/tls"
-	"net/url"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -12,6 +12,7 @@ import (
 	"github.com/alphagov/paas-cf-apps-statsd/processors"
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/cloudfoundry/noaa/consumer"
+	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/quipo/statsd"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -124,6 +125,22 @@ func (m *metricProcessor) authenticate() (err error) {
 	return nil
 }
 
+func updateAppSpaceData(app *cfclient.App) error {
+	if app.SpaceData == (cfclient.SpaceResource{}) {
+		space, err := app.Space()
+		if err != nil {
+			return err
+		}
+		org, err := space.Org()
+		if err != nil {
+			return err
+		}
+		space.OrgData.Entity = org
+		app.SpaceData.Entity = space
+	}
+	return nil
+}
+
 func (m *metricProcessor) updateApps() error {
 
 	authToken, err := m.cfClient.GetToken()
@@ -141,6 +158,10 @@ func (m *metricProcessor) updateApps() error {
 	for _, app := range apps {
 		runningApps[app.Guid] = true
 		if _, ok := m.watchedApps[app.Guid]; !ok {
+			err = updateAppSpaceData(&app)
+			if err != nil {
+				return err
+			}
 			conn := consumer.New(m.cfClient.Endpoint.DopplerEndpoint, &tls.Config{InsecureSkipVerify: *skipSSLValidation}, nil)
 			msg, err := conn.Stream(app.Guid, authToken)
 

--- a/main_test.go
+++ b/main_test.go
@@ -98,6 +98,11 @@ var _ = Describe("Main", func() {
 	Describe("updateApps", func() {
 		var apps []cfclient.App
 
+		const (
+			spaceGuid = "25F4B52E-E16C-4E1F-A529-E45C2DB9AC07"
+			orgGuid   = "98C535C1-A4F8-4066-8384-733E1ADCADEE"
+		)
+
 		Context("no watchers and no running apps", func() {
 			BeforeEach(func() {
 				metricProc.watchedApps = map[string]*consumer.Consumer{}
@@ -123,15 +128,39 @@ var _ = Describe("Main", func() {
 			BeforeEach(func() {
 				metricProc.watchedApps = map[string]*consumer.Consumer{}
 				apps = []cfclient.App{
-					{Guid: "11111111-1111-1111-1111-111111111111"},
-					{Guid: "22222222-2222-2222-2222-222222222222"},
-					{Guid: "33333333-3333-3333-3333-333333333333"},
+					{Guid: "11111111-1111-1111-1111-111111111111", SpaceURL: "/v2/spaces/" + spaceGuid},
+					{Guid: "22222222-2222-2222-2222-222222222222", SpaceURL: "/v2/spaces/" + spaceGuid},
+					{Guid: "33333333-3333-3333-3333-333333333333", SpaceURL: "/v2/spaces/" + spaceGuid},
 				}
 
 				apiServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/v2/apps"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, testAppResponse(apps)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
 					),
 				)
 			})
@@ -169,14 +198,14 @@ var _ = Describe("Main", func() {
 			BeforeEach(func() {
 				metricProc.watchedApps = map[string]*consumer.Consumer{}
 				appsBefore = []cfclient.App{
-					{Guid: "11111111-1111-1111-1111-111111111111"},
-					{Guid: "22222222-2222-2222-2222-222222222222"},
-					{Guid: "33333333-3333-3333-3333-333333333333"},
+					{Guid: "11111111-1111-1111-1111-111111111111", SpaceURL: "/v2/spaces/" + spaceGuid},
+					{Guid: "22222222-2222-2222-2222-222222222222", SpaceURL: "/v2/spaces/" + spaceGuid},
+					{Guid: "33333333-3333-3333-3333-333333333333", SpaceURL: "/v2/spaces/" + spaceGuid},
 				}
 				apps = []cfclient.App{
-					{Guid: "33333333-3333-3333-3333-333333333333"},
-					{Guid: "44444444-4444-4444-4444-444444444444"},
-					{Guid: "55555555-5555-5555-5555-555555555555"},
+					{Guid: "33333333-3333-3333-3333-333333333333", SpaceURL: "/v2/spaces/" + spaceGuid},
+					{Guid: "44444444-4444-4444-4444-444444444444", SpaceURL: "/v2/spaces/" + spaceGuid},
+					{Guid: "55555555-5555-5555-5555-555555555555", SpaceURL: "/v2/spaces/" + spaceGuid},
 				}
 
 				apiServer.AppendHandlers(
@@ -185,8 +214,48 @@ var _ = Describe("Main", func() {
 						ghttp.RespondWithJSONEncoded(http.StatusOK, testAppResponse(appsBefore)),
 					),
 					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
+					),
+					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/v2/apps"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, testAppResponse(apps)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/spaces/"+spaceGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testSpaceResource(spaceGuid, orgGuid)),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/v2/organizations/"+orgGuid),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, testOrgResource(orgGuid)),
 					),
 				)
 			})
@@ -390,6 +459,20 @@ func testAppResponse(apps []cfclient.App) cfclient.AppResponse {
 	}
 
 	return resp
+}
+
+func testSpaceResource(spaceGuid, orgGuid string) cfclient.SpaceResource {
+	return cfclient.SpaceResource{
+		Meta:   cfclient.Meta{Guid: spaceGuid},
+		Entity: cfclient.Space{OrgURL: "/v2/organizations/" + orgGuid},
+	}
+}
+
+func testOrgResource(orgGuid string) cfclient.OrgResource {
+	return cfclient.OrgResource{
+		Meta:   cfclient.Meta{Guid: orgGuid},
+		Entity: cfclient.Org{},
+	}
 }
 
 func testNewEvent(appGuid string) *events.Envelope {


### PR DESCRIPTION
This PR is for the 2 most urgent changes, as requested in #6.

The first change is filtering the event stream and processing only `Envelope_ContainerMetric` events. Other events should not be processed as they generate 0 value metrics which is incorrect.

The second change is addressing an issue where org name and space name would be empty, breaking dashboards based on filtering of these values.