### PR TITLE
Fix yaml example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ applications:
     SKIP_SSL_VALIDATION: false
     DEBUG: false
     UPDATE_FREQUENCY: 300
-    METRIC_TEMPLATE: {{.Space}}.{{.App}}.{{.Metric}}
+    METRIC_TEMPLATE: "{{.Space}}.{{.App}}.{{.Metric}}"
 ```
 
 Be sure to provide credentials for the user assigned to the correct space(s), with ability to list applications.


### PR DESCRIPTION
If you don't quote the METRIC_TEMPLATE value, then the cf cli yaml
parser gets confused by the curly brackets and tries to parse them as
a yaml object.  This results in the error message "did not find
expected key" which is not super helpful :(

This was fixed by quoting the string.  I'm updating the README to make
this clearer for future users.