### PR TITLE
Remove production ready warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # paas-cf-apps-statsd
 
 This application consumes container metrics off the Cloud Foundry Doppler daemon, processes them based on provided metrics template, and then sends them off to a StatsD endpoint.
-CPU, RAM and disk usage metrics for app containers will be sent through to StatsD as a Gauge metric. It will get metrics for all applications provided user has access to. Note that it is still being developed and shouldn't be considered production-ready.
+CPU, RAM and disk usage metrics for app containers will be sent through to StatsD as a Gauge metric. It will get metrics for all applications provided user has access to.
 
 The application is somewhat based on [`pivotal-cf/graphite-nozzle`](https://github.com/pivotal-cf/graphite-nozzle).
 


### PR DESCRIPTION
## What

At least one tenant has been using this in production for several months
now. We know of one bug, to do with reporting the wrong app name during
blue-green deployments, but that doesn't affect it's general stability. So
remove the notice which might scare people away from using it.

## How to review

Check that I've removed all references and that my rationale makes sense.

## Who can review

Anyone.