### PR TITLE
Removed unused variables in tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -364,16 +364,12 @@ var _ = Describe("Main", func() {
 		}
 
 		var (
-			apps            []cfclient.App
-			teapot          string
-			calledEndpoints map[string]int
-			tkj             tokenJSON
+			apps []cfclient.App
+			tkj  tokenJSON
 		)
 
 		Context("refreshToken has expired", func() {
 			BeforeEach(func() {
-				teapot = `{"status":"teapot"}`
-
 				tkj = tokenJSON{
 					AccessToken:  "access",
 					TokenType:    "bearer",
@@ -381,8 +377,6 @@ var _ = Describe("Main", func() {
 					ExpiresIn:    5,
 					Expires:      5,
 				}
-
-				calledEndpoints = map[string]int{}
 
 				apps = []cfclient.App{
 					{Guid: "55555555-5555-5555-5555-555555555555"},


### PR DESCRIPTION
## What

These cause Travis to fail the build against Go master:

    $ go test -v ./...
    # github.com/alphagov/paas-cf-apps-statsd
    ./main_test.go:368:4: teapot declared but not used
    ./main_test.go:369:4: calledEndpoints declared but not used
    vet: typecheck failures

This fixes the build failure seen in #11.

## How to review

Code review and check that Travis passes all tests in the build matrix.

## Who can review

Anyone.