### PR TITLE
Fix the link to the metrics section in the tech docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The application is based on [`pivotal-cf/graphite-nozzle`](https://github.com/pi
 
 ## Getting Started
 
-Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/#exporting-metrics-data) for instructions on how to set up the metrics exporter app. Information on the configuration options are in the following table.
+Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/#metrics) for instructions on how to set up the metrics exporter app. Information on the configuration options are in the following table.
 
 
 |Configuration Option|Application Flag|Environment Variable|Notes|


### PR DESCRIPTION
## What

Fix the link to the section in the tech docs. Which was broken by alphagov/paas-tech-docs#86

## How to review

Ensure that the link goes to a relevant part of the docs.

## Who can review

Not me