### PR TITLE
[#141496629] Routing metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
 before_install:
   - go get github.com/onsi/ginkgo/ginkgo
 
-scripts:
-  - ginkgo -r
+script:
+  - make test

--- a/README.md
+++ b/README.md
@@ -12,10 +12,22 @@ The following metrics will be exported for every application instance.
 
 |Name|Type|Description|
 |:---|:---|:---|
-|cpu|gauge|CPU utilisation|
-|diskBytes|gauge|Disk usage in bytes|
-|memoryBytes|gauge|Memory usage in bytes|
-|crash|counter|Increased by one if the application crashed for any reason.|
+|`cpu`|gauge|CPU utilisation|
+|`diskBytes`|gauge|Disk usage in bytes|
+|`memoryBytes`|gauge|Memory usage in bytes|
+|`crash`|counter|Increased by one if the application crashed for any reason|
+|`requests.1xx`|counter|Number of requests processed with 1xx status|
+|`requests.2xx`|counter|Number of requests processed with 2xx status|
+|`requests.3xx`|counter|Number of requests processed with 3xx status|
+|`requests.4xx`|counter|Number of requests processed with 4xx status|
+|`requests.5xx`|counter|Number of requests processed with 5xx status|
+|`requests.other`|counter|Number of requests processed with unknown status|
+|`responseTime.1xx`|timer|Timing of processed requests with 1xx status|
+|`responseTime.2xx`|timer|Timing of processed requests with 2xx status|
+|`responseTime.3xx`|timer|Timing of processed requests with 3xx status|
+|`responseTime.4xx`|timer|Timing of processed requests with 4xx status|
+|`responseTime.5xx`|timer|Timing of processed requests with 5xx status|
+|`responseTime.other`|timer|Timing of processed requests with unknown status|
 
 ## Getting Started
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -156,7 +156,7 @@ var _ = Describe("App", func() {
 	})
 
 	Context("when the processor fails to process the event", func() {
-		It("should continue to process eventsd", func() {
+		It("should continue to process events", func() {
 			proc1.ProcessReturnsOnCall(0, nil, errors.New("some processing error"))
 			validEventType := sonde_events.Envelope_ContainerMetric
 			event1 := &events.AppEvent{Envelope: &sonde_events.Envelope{EventType: &validEventType}}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	processors := map[sonde_events.Envelope_EventType]processors.Processor{
 		sonde_events.Envelope_ContainerMetric: processors.NewContainerMetricProcessor(*metricTemplate),
 		sonde_events.Envelope_LogMessage:      processors.NewLogMessageProcessor(*metricTemplate),
+		sonde_events.Envelope_HttpStartStop:   processors.NewHttpStartStopProcessor(*metricTemplate),
 	}
 
 	var sender metrics.StatsdClient

--- a/processors/http_start_stop_processor.go
+++ b/processors/http_start_stop_processor.go
@@ -1,0 +1,78 @@
+package processors
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/alphagov/paas-metric-exporter/events"
+	"github.com/alphagov/paas-metric-exporter/metrics"
+	sonde_events "github.com/cloudfoundry/sonde-go/events"
+)
+
+type HttpStartStopProcessor struct {
+	tmpl string
+}
+
+func NewHttpStartStopProcessor(tmpl string) *HttpStartStopProcessor {
+	return &HttpStartStopProcessor{tmpl: tmpl}
+}
+
+func (p *HttpStartStopProcessor) Process(appEvent *events.AppEvent) ([]metrics.Metric, error) {
+	httpStartStop := appEvent.Envelope.GetHttpStartStop()
+	if httpStartStop.GetPeerType() != sonde_events.PeerType_Client {
+		return []metrics.Metric{}, nil
+	}
+
+	requestCountMetric, err := p.requestCount(httpStartStop, metrics.NewVars(appEvent))
+	if err != nil {
+		return []metrics.Metric{}, nil
+	}
+	responseTimeMetric, err := p.responseTime(httpStartStop, metrics.NewVars(appEvent))
+	if err != nil {
+		return []metrics.Metric{}, nil
+	}
+	return []metrics.Metric{requestCountMetric, responseTimeMetric}, nil
+}
+
+func (p *HttpStartStopProcessor) requestCount(httpStartStop *sonde_events.HttpStartStop, vars *metrics.Vars) (metrics.Metric, error) {
+	vars.Metric = "requests." + statusClass(int(*httpStartStop.StatusCode))
+	vars.Instance = fmt.Sprintf("%d", *httpStartStop.InstanceIndex)
+	metricStat, err := vars.RenderTemplate(p.tmpl)
+	if err != nil {
+		return nil, err
+	}
+	return metrics.NewCounterMetric(metricStat, 1), nil
+}
+
+func (p *HttpStartStopProcessor) responseTime(httpStartStop *sonde_events.HttpStartStop, vars *metrics.Vars) (metrics.Metric, error) {
+	vars.Metric = "responseTime." + statusClass(int(*httpStartStop.StatusCode))
+	vars.Instance = fmt.Sprintf("%d", *httpStartStop.InstanceIndex)
+	metricStat, err := vars.RenderTemplate(p.tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	startTimestamp := httpStartStop.GetStartTimestamp()
+	stopTimestamp := httpStartStop.GetStopTimestamp()
+	elapsedDuration := time.Duration(stopTimestamp - startTimestamp)
+	return metrics.NewPrecisionTimingMetric(metricStat, elapsedDuration), nil
+}
+
+func statusClass(statusCode int) string {
+	switch {
+	case statusCode < 100:
+		return "other"
+	case statusCode < 200:
+		return "1xx"
+	case statusCode < 300:
+		return "2xx"
+	case statusCode < 400:
+		return "3xx"
+	case statusCode < 500:
+		return "4xx"
+	case statusCode < 600:
+		return "5xx"
+	default:
+		return "other"
+	}
+}

--- a/processors/http_start_stop_processor_test.go
+++ b/processors/http_start_stop_processor_test.go
@@ -1,0 +1,101 @@
+package processors_test
+
+import (
+	"github.com/alphagov/paas-metric-exporter/events"
+	"github.com/alphagov/paas-metric-exporter/metrics"
+	. "github.com/alphagov/paas-metric-exporter/processors"
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	sonde_events "github.com/cloudfoundry/sonde-go/events"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HttpStartStopProcessor", func() {
+	var (
+		processor                      *HttpStartStopProcessor
+		tmpl                           string
+		envelopeHttpStartStopEventType sonde_events.Envelope_EventType
+		httpStatusTestCases            = map[string]int32{
+			"1xx":   100,
+			"2xx":   200,
+			"3xx":   301,
+			"4xx":   401,
+			"5xx":   500,
+			"other": 0,
+		}
+	)
+
+	BeforeEach(func() {
+		tmpl = "apps.{{.GUID}}.{{.Instance}}.{{.Metric}}"
+		processor = NewHttpStartStopProcessor(tmpl)
+
+		envelopeHttpStartStopEventType = sonde_events.Envelope_HttpStartStop
+	})
+
+	Describe("#Process", func() {
+		for statusRange, statusCode := range httpStatusTestCases {
+			Context(statusRange, func() {
+				var (
+					applicationID      string
+					httpStartStopEvent *events.AppEvent
+				)
+
+				BeforeEach(func() {
+					applicationID = "4630f6ba-8ddc-41f1-afea-1905332d6660"
+					startTimestamp := int64(0)
+					stopTimestamp := int64(11 * time.Millisecond)
+					clientPeerType := sonde_events.PeerType_Client
+					getMethod := sonde_events.Method_GET
+					instanceIndex := int32(0)
+
+					httpStartStopEvent = &events.AppEvent{
+						App: cfclient.App{
+							Guid: applicationID,
+						},
+						Envelope: &sonde_events.Envelope{
+							EventType: &envelopeHttpStartStopEventType,
+							HttpStartStop: &sonde_events.HttpStartStop{
+								StartTimestamp: &startTimestamp,
+								StopTimestamp:  &stopTimestamp,
+								PeerType:       &clientPeerType,
+								Method:         &getMethod,
+								Uri:            str("/"),
+								StatusCode:     &statusCode,
+								InstanceIndex:  &instanceIndex,
+							},
+						},
+					}
+				})
+
+				It("returns requests counter metric", func() {
+					processedMetrics, err := processor.Process(httpStartStopEvent)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(processedMetrics).To(ContainElement(&metrics.CounterMetric{
+						Stat:  "apps." + applicationID + ".0.requests." + statusRange,
+						Value: 1,
+					}))
+				})
+
+				It("returns response_time timer metric", func() {
+					processedMetrics, err := processor.Process(httpStartStopEvent)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(processedMetrics).To(ContainElement(&metrics.PrecisionTimingMetric{
+						Stat:  "apps." + applicationID + ".0.responseTime." + statusRange,
+						Value: 11 * time.Millisecond,
+					}))
+				})
+
+				It("ignores metrics with a Server PeerType", func() {
+					serverPeerType := sonde_events.PeerType_Server
+					httpStartStopEvent.Envelope.HttpStartStop.PeerType = &serverPeerType
+
+					processedMetrics, err := processor.Process(httpStartStopEvent)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(processedMetrics).To(BeEmpty())
+				})
+			})
+		}
+	})
+})

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -13,3 +13,5 @@ type Processor interface {
 var _ Processor = &ContainerMetricProcessor{}
 
 var _ Processor = &LogMessageProcessor{}
+
+var _ Processor = &HttpStartStopProcessor{}


### PR DESCRIPTION
## What

We've added new metrics for monitoring request rates:

* `requests.*`: a request counter, grouped by status code class (ie 2xx, 4xx, 5xx) 
* `responseTime.*`: a response time timer in `ms`, also grouped by status code class

## How to review

You can run the app locally in debug mode to watch the events emitted by making requests to an app that is running in the space.
 
```
go run main.go --api-endpoint "https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital" --skip-ssl-validation --username <user> --password <pass> --debug
```

## Who can review

Not @46bit @chrisfarms 