### PR TITLE
[#141496629] Fix missing Space/Org data

### DIFF
--- a/events/fetcher.go
+++ b/events/fetcher.go
@@ -158,11 +158,12 @@ func (m *Fetcher) getApps() ([]cfclient.App, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, app := range apps {
-		if err = updateAppSpaceData(&app); err != nil {
+	for i, _ := range apps {
+		if err = updateAppSpaceData(&apps[i]); err != nil {
 			return nil, err
 		}
 	}
+
 	return apps, nil
 }
 
@@ -181,7 +182,6 @@ func (m *Fetcher) updateApps() error {
 	if err != nil {
 		return err
 	}
-
 	running := map[string]bool{}
 	for _, app := range apps {
 		running[app.Guid] = true


### PR DESCRIPTION
## What

`{{.Space}}` and `{{.Organisation}}` values were not being rendered in metric templates.

This appears to be a bug that was introduced a while ago, so it's possible there are tenants relying on the existing behaviour of the default metric template NOT including the space name.

## How to review

* Check that metrics include the expected values as per the default metric template
* Consider if we need to change the default metric template to reflect the old (buggy) behaviour
* Consider if we need to notify any tenants of the fix

## Who can review

Not @chrisfarms / @46bit 