### PR TITLE
Set GOPACKAGENAME in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,5 +4,7 @@ applications:
   memory: 100M
   instances: 1
   buildpack: go_buildpack
+  env:
+    GOPACKAGENAME: github.com/alphagov/paas-metric-exporter
   health-check-type: none
   no-route: true


### PR DESCRIPTION
## What

Due to switching from godep to dep for dependency management we now need
to set GOPACKAGENAME in the manifest in order for the package to build
on CF.

## How to review

Push the app from this branch using the documentation located at https://docs.cloud.service.gov.uk/#metrics

Also see #paas-users

## Who can review?

Not @LeePorte