### PR TITLE
Set the GOPACKAGENAME for go native dependencies

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,5 @@ applications:
   buildpack: go_buildpack
   health-check-type: none
   no-route: true
+  env:
+    GOPACKAGENAME: github.com/alphagov/paas-metric-exporter


### PR DESCRIPTION
As per https://docs.cloudfoundry.org/buildpacks/go/index.html#push-an-app-with-native-go-vendoring the GOPACKAGENAME is required when using Go native deps.  Without this the app will failed to deploy with an exit status of 223