### PR TITLE
Automatically add dot suffix to STATSD_PREFIX opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/#m
 |:---|:---|:---|:---|
 |API endpoint|api-endpoint|API_ENDPOINT||
 |Statsd endpoint|statsd-endpoint|STATSD_ENDPOINT||
-|Statsd prefix|statsd-prefix|STATSD_PREFIX||
+|Statsd prefix|statsd-prefix|STATSD_PREFIX|Namespace prepended to all emitted metric names. The default is `mycf`|
 |Username|username|USERNAME||
 |Password|password|PASSWORD||
 |Skip SSL Validation|skip-ssl-validation|SKIP_SSL_VALIDATION||

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/#m
 |:---|:---|:---|:---|
 |API endpoint|api-endpoint|API_ENDPOINT||
 |Statsd endpoint|statsd-endpoint|STATSD_ENDPOINT||
-|Statsd prefix|statsd-prefix|STATSD_PREFIX|Namespace prepended to all emitted metric names. The default is `mycf`|
+|Statsd prefix|statsd-prefix|STATSD_PREFIX|Namespace prepended to all emitted metric names. The default is `mycf` which results in metrics names like `mycf.cpu`, `mycf.diskBytes` etc|
 |Username|username|USERNAME||
 |Password|password|PASSWORD||
 |Skip SSL Validation|skip-ssl-validation|SKIP_SSL_VALIDATION||

--- a/statsd/debug.go
+++ b/statsd/debug.go
@@ -6,29 +6,30 @@ import (
 )
 
 type DebugClient struct {
+	Prefix string
 }
 
 func (d DebugClient) Gauge(stat string, value int64) error {
-	log.Printf("gauge %s %d\n", stat, value)
+	log.Printf("gauge %s %d\n", d.Prefix+stat, value)
 	return nil
 }
 
 func (d DebugClient) FGauge(stat string, value float64) error {
-	log.Printf("gauge %s %f\n", stat, value)
+	log.Printf("gauge %s %f\n", d.Prefix+stat, value)
 	return nil
 }
 
 func (d DebugClient) Incr(stat string, count int64) error {
-	log.Printf("incr %s %d\n", stat, count)
+	log.Printf("incr %s %d\n", d.Prefix+stat, count)
 	return nil
 }
 
 func (d DebugClient) Timing(stat string, delta int64) error {
-	log.Printf("timing %s %d\n", stat, delta)
+	log.Printf("timing %s %d\n", d.Prefix+stat, delta)
 	return nil
 }
 
 func (d DebugClient) PrecisionTiming(stat string, delta time.Duration) error {
-	log.Printf("timing %s %d\n", stat, delta)
+	log.Printf("timing %s %d\n", d.Prefix+stat, delta)
 	return nil
 }


### PR DESCRIPTION
# What

StatsD metric names are in a dot separated notation. It was previously not clear that you should add a trailing dot when setting a custom prefix via the STATSD_PREFIX or --statsd-prefix options.

To make for a better user experience we now add the trailing dot automatically.

# How to review

You can check if the prefix option is getting normalized correctly by using the debug output:

```
go run main.go --api-endpoint "https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital" --skip-ssl-validation --username admin --password ${UAA_ADMIN_PASSWORD} --debug --statsd-prefix "withoutadot"
```

and it should still join names correctly when a dot is given:

```
go run main.go --api-endpoint "https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital" --skip-ssl-validation --username admin --password ${UAA_ADMIN_PASSWORD} --debug --statsd-prefix "withadot."
```

# Who can review

Not @chrisfarms