### PR TITLE
[#153780375] Add percent utilised metrics to the exporter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ You can use following template fields in your metric template:
 * `{{.App}}` - name of the application
 * `{{.CellId}}` - Cell GUID
 * `{{.GUID}}` - Application ID
-* `{{.Index}}` - BOSH job index e.g. `0`
 * `{{.Instance}}` - Application instance
 * `{{.Job}}` - BOSH job name e.g `cell`
 * `{{.Metric}}` - a metric from the list of available metrics

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The following metrics will be exported for every application instance.
 |:---|:---|:---|
 |`cpu`|gauge|CPU utilisation|
 |`diskBytes`|gauge|Disk usage in bytes|
+|`diskUtilization`|gauge|Disk utilisation in percent (0-100)|
 |`memoryBytes`|gauge|Memory usage in bytes|
+|`memoryUtilization`|gauge|Memory utilisation in percent (0-100)|
 |`crash`|counter|Increased by one if the application crashed for any reason|
 |`requests.1xx`|counter|Number of requests processed with 1xx status|
 |`requests.2xx`|counter|Number of requests processed with 2xx status|

--- a/metrics/metric.go
+++ b/metrics/metric.go
@@ -29,7 +29,6 @@ type CounterMetric struct {
 	App          string
 	CellId       string
 	GUID         string
-	Index        string
 	Instance     string
 	Job          string
 	Metric       string
@@ -56,7 +55,6 @@ type GaugeMetric struct {
 	App          string
 	CellId       string
 	GUID         string
-	Index        string
 	Instance     string
 	Job          string
 	Metric       string
@@ -83,7 +81,6 @@ type FGaugeMetric struct {
 	App          string
 	CellId       string
 	GUID         string
-	Index        string
 	Instance     string
 	Job          string
 	Metric       string
@@ -110,7 +107,6 @@ type TimingMetric struct {
 	App          string
 	CellId       string
 	GUID         string
-	Index        string
 	Instance     string
 	Job          string
 	Metric       string
@@ -137,7 +133,6 @@ type PrecisionTimingMetric struct {
 	App          string
 	CellId       string
 	GUID         string
-	Index        string
 	Instance     string
 	Job          string
 	Metric       string

--- a/metrics/metric.go
+++ b/metrics/metric.go
@@ -4,6 +4,12 @@ import (
 	"time"
 )
 
+var _ Metric = CounterMetric{}
+var _ Metric = GaugeMetric{}
+var _ Metric = FGaugeMetric{}
+var _ Metric = TimingMetric{}
+var _ Metric = PrecisionTimingMetric{}
+
 //go:generate counterfeiter -o mocks/statsd_client.go . StatsdClient
 type StatsdClient interface {
 	Gauge(stat string, value int64) error

--- a/processors/container_metric_processor_test.go
+++ b/processors/container_metric_processor_test.go
@@ -2,9 +2,11 @@ package processors_test
 
 import (
 	"github.com/alphagov/paas-metric-exporter/events"
+	"github.com/alphagov/paas-metric-exporter/metrics"
 	. "github.com/alphagov/paas-metric-exporter/processors"
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	sonde_events "github.com/cloudfoundry/sonde-go/events"
+	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -22,71 +24,124 @@ var _ = Describe("ContainerMetricProcessor", func() {
 		processor = &ContainerMetricProcessor{}
 
 		applicationId := "60a13b0f-fce7-4c02-b92a-d43d583877ed"
-		instanceIndex := int32(0)
-		cpuPercentage := float64(70.75)
-		memoryBytes := uint64(1024)
-		diskBytes := uint64(2048)
 
 		containerMetricEvent = &sonde_events.ContainerMetric{
-			ApplicationId: &applicationId,
-			InstanceIndex: &instanceIndex,
-			CpuPercentage: &cpuPercentage,
-			MemoryBytes:   &memoryBytes,
-			DiskBytes:     &diskBytes,
+			ApplicationId:    proto.String(applicationId),
+			InstanceIndex:    proto.Int32(1),
+			CpuPercentage:    proto.Float64(70.75),
+			MemoryBytes:      proto.Uint64(16 * 1024 * 1024),
+			MemoryBytesQuota: proto.Uint64(32 * 1024 * 1024),
+			DiskBytes:        proto.Uint64(25 * 1024 * 1024),
+			DiskBytesQuota:   proto.Uint64(100 * 1024 * 1024),
 		}
 
 		event = &sonde_events.Envelope{
 			ContainerMetric: containerMetricEvent,
+			Index:           proto.String("cell-id"),
+			Job:             proto.String("job-name"),
 		}
 
 		appEvent = &events.AppEvent{
 			App: cfclient.App{
+				Name: "app-name",
 				Guid: applicationId,
+				SpaceData: cfclient.SpaceResource{
+					Entity: cfclient.Space{
+						Name: "space-name",
+						OrgData: cfclient.OrgResource{
+							Entity: cfclient.Org{
+								Name: "org-name",
+							},
+						},
+					},
+				},
 			},
 			Envelope: event,
 		}
 	})
 
-	Describe("#Process", func() {
+	Describe("Process", func() {
 		It("returns a Metric for each of the ProcessContainerMetric* methods", func() {
 			processedMetrics, err := processor.Process(appEvent)
 
 			Expect(err).To(BeNil())
-			Expect(processedMetrics).To(HaveLen(3))
+			Expect(processedMetrics).To(HaveLen(5))
+
+			expectedCPUMetric := metrics.GaugeMetric{
+				Instance:     "1",
+				App:          "app-name",
+				GUID:         "60a13b0f-fce7-4c02-b92a-d43d583877ed",
+				CellId:       "cell-id",
+				Job:          "job-name",
+				Organisation: "org-name",
+				Space:        "space-name",
+				Metric:       "cpu",
+				Value:        70,
+			}
+			Expect(processedMetrics).To(ContainElement(expectedCPUMetric))
+
+			expectedMemoryMetric := metrics.GaugeMetric{
+				Instance:     "1",
+				App:          "app-name",
+				GUID:         "60a13b0f-fce7-4c02-b92a-d43d583877ed",
+				CellId:       "cell-id",
+				Job:          "job-name",
+				Organisation: "org-name",
+				Space:        "space-name",
+				Metric:       "memoryBytes",
+				Value:        16 * 1024 * 1024,
+			}
+			Expect(processedMetrics).To(ContainElement(expectedMemoryMetric))
+
+			expectedMemoryUtilisationMetric := metrics.GaugeMetric{
+				Instance:     "1",
+				App:          "app-name",
+				GUID:         "60a13b0f-fce7-4c02-b92a-d43d583877ed",
+				CellId:       "cell-id",
+				Job:          "job-name",
+				Organisation: "org-name",
+				Space:        "space-name",
+				Metric:       "memoryUtilization",
+				Value:        50,
+			}
+			Expect(processedMetrics).To(ContainElement(expectedMemoryUtilisationMetric))
+
+			expectedDiskMetric := metrics.GaugeMetric{
+				Instance:     "1",
+				App:          "app-name",
+				GUID:         "60a13b0f-fce7-4c02-b92a-d43d583877ed",
+				CellId:       "cell-id",
+				Job:          "job-name",
+				Organisation: "org-name",
+				Space:        "space-name",
+				Metric:       "diskBytes",
+				Value:        25 * 1024 * 1024,
+			}
+			Expect(processedMetrics).To(ContainElement(expectedDiskMetric))
+
+			expectedDiskUtilisationMetric := metrics.GaugeMetric{
+				Instance:     "1",
+				App:          "app-name",
+				GUID:         "60a13b0f-fce7-4c02-b92a-d43d583877ed",
+				CellId:       "cell-id",
+				Job:          "job-name",
+				Organisation: "org-name",
+				Space:        "space-name",
+				Metric:       "diskUtilization",
+				Value:        25,
+			}
+			Expect(processedMetrics).To(ContainElement(expectedDiskUtilisationMetric))
 		})
-	})
 
-	Describe("#ProcessContainerMetricCPU", func() {
-		It("sets the Metric Value to the value of the ContainerMetric cpuPercentage", func() {
-			metric, err := processor.ProcessContainerMetric("cpu", appEvent)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(metric.Value).To(Equal(int64(70)))
+		It("returns an error if memory quota is zero", func() {
+			containerMetricEvent.MemoryBytesQuota = proto.Uint64(0)
+			_, err := processor.Process(appEvent)
+			Expect(err).To(HaveOccurred())
 		})
-	})
 
-	Describe("#ProcessContainerMetricMemory", func() {
-		It("sets the Metric Value to the value of the ContainerMetric memoryBytes", func() {
-			metric, err := processor.ProcessContainerMetric("mem", appEvent)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(metric.Value).To(Equal(int64(1024)))
-		})
-	})
-
-	Describe("#ProcessContainerMetricDisk", func() {
-		It("sets the Metric Value to the value of the ContainerMetric diskBytes", func() {
-			metric, err := processor.ProcessContainerMetric("dsk", appEvent)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(metric.Value).To(Equal(int64(2048)))
-		})
-	})
-
-	Describe("#ProcessContainerMetricUnknown", func() {
-		It("should fail", func() {
-			_, err := processor.ProcessContainerMetric("unknown", appEvent)
-
+		It("returns an error if disk quota is zero", func() {
+			containerMetricEvent.DiskBytesQuota = proto.Uint64(0)
+			_, err := processor.Process(appEvent)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
## What

We added the calculated memory utilisation and disk utilisation values to the exported metrics. The tenants can't calculate these values easily as we don't export the current quota.

Also we removed the unused Index field from the metric template as it was always empty and there is no ```BOSH job id``` in the exported metrics from CF.

## How to review

1. Run the metrics-exporter in debug mode and check for the new values:
```STATSD_PREFIX="." go run main.go --api-endpoint "https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital" --skip-ssl-validation --username admin --password ${UAA_ADMIN_PASSWORD} --debug```

## Who can review

Not @chrisfarms or @bandesz
