### PR TITLE
Add prometheus manifest file

### DIFF
--- a/manifest-prometheus.yml
+++ b/manifest-prometheus.yml
@@ -1,0 +1,10 @@
+---
+applications:
+- name: metric-exporter
+  memory: 100M
+  instances: 1
+  buildpack: go_buildpack
+  env:
+    GOPACKAGENAME: github.com/alphagov/paas-metric-exporter
+    ENABLE_STATSD: false
+    ENABLE_PROMETHEUS: true


### PR DESCRIPTION
This adds a separate manifest that can be pushed using
`cf push -f manifest-prometheus.yml`.

It's not easy to create a prometheus exporter using the existing
manifest, because as well as calling `cf set-env` to enable prometheus
and disable statsd, you also have to bind a route to it and set up a
health check because the manifest specifies "no-route: true" and
"health-check-type: false".  It's much easier to have a separate
manifest that doesn't specify these options so that you get your route
and health check for free on initial push.