### PR TITLE
[#159142216] Expire old metrics seen when using prometheus

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -66,10 +66,17 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/hashstructure"
+  packages = ["."]
+  revision = "2bca23e0e452137f789efbc8610126fd8b94f73b"
+
+[[projects]]
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
     "config",
+    "extensions/table",
     "internal/codelocation",
     "internal/containernode",
     "internal/failer",
@@ -188,6 +195,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fb8e22c32a96bebec59e7bc70aa269d0f7f371b5aa7be32ffa30d611de8a02ae"
+  inputs-digest = "3d5f92522d6ab96ba27bafa89d9380c7af99c106045812858571b61b4fa066a7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alphagov/paas-metric-exporter/senders"
 	"github.com/cloudfoundry-community/go-cfclient"
 	sonde_events "github.com/cloudfoundry/sonde-go/events"
+	"github.com/prometheus/client_golang/prometheus"
 	quipo_statsd "github.com/quipo/statsd"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -87,7 +88,10 @@ func main() {
 		metricSenders = append(metricSenders, sender)
 	} else {
 		if *enablePrometheus {
-			metricSenders = append(metricSenders, senders.NewPrometheusSender())
+			metricSenders = append(
+				metricSenders,
+				senders.NewPrometheusSender(prometheus.DefaultRegisterer),
+			)
 		}
 
 		if *enableStatsd {

--- a/main.go
+++ b/main.go
@@ -18,19 +18,20 @@ import (
 )
 
 var (
-	apiEndpoint        = kingpin.Flag("api-endpoint", "API endpoint").Default("https://api.10.244.0.34.xip.io").OverrideDefaultFromEnvar("API_ENDPOINT").String()
-	statsdEndpoint     = kingpin.Flag("statsd-endpoint", "Statsd endpoint").Default("10.244.11.2:8125").OverrideDefaultFromEnvar("STATSD_ENDPOINT").String()
-	statsdPrefix       = kingpin.Flag("statsd-prefix", "Statsd prefix").Default("mycf.").OverrideDefaultFromEnvar("STATSD_PREFIX").String()
-	username           = kingpin.Flag("username", "UAA username.").Default("").OverrideDefaultFromEnvar("USERNAME").String()
-	password           = kingpin.Flag("password", "UAA password.").Default("").OverrideDefaultFromEnvar("PASSWORD").String()
-	skipSSLValidation  = kingpin.Flag("skip-ssl-validation", "Please don't").Default("false").OverrideDefaultFromEnvar("SKIP_SSL_VALIDATION").Bool()
-	debug              = kingpin.Flag("debug", "Enable debug mode. This disables forwarding to statsd and prometheus and prints to stdout").Default("false").OverrideDefaultFromEnvar("DEBUG").Bool()
-	updateFrequency    = kingpin.Flag("update-frequency", "The time in seconds, that takes between each apps update call.").Default("300").OverrideDefaultFromEnvar("UPDATE_FREQUENCY").Int64()
-	metricTemplate     = kingpin.Flag("metric-template", "The template that will form a new metric namespace.").Default(senders.DefaultTemplate).OverrideDefaultFromEnvar("METRIC_TEMPLATE").String()
-	metricWhitelist    = kingpin.Flag("metric-whitelist", "Comma separated metric name prefixes to enable.").Default("").OverrideDefaultFromEnvar("METRIC_WHITELIST").String()
-	prometheusBindPort = kingpin.Flag("prometheus-bind-port", "The port to bind to for prometheus metrics.").Default("8080").OverrideDefaultFromEnvar("PORT").Int()
-	enableStatsd       = kingpin.Flag("enable-statsd", "Enable the statsd sender.").Default("true").OverrideDefaultFromEnvar("ENABLE_STATSD").Bool()
-	enablePrometheus   = kingpin.Flag("enable-prometheus", "Enable the prometheus sender.").Default("false").OverrideDefaultFromEnvar("ENABLE_PROMETHEUS").Bool()
+	apiEndpoint         = kingpin.Flag("api-endpoint", "API endpoint").Default("https://api.10.244.0.34.xip.io").OverrideDefaultFromEnvar("API_ENDPOINT").String()
+	statsdEndpoint      = kingpin.Flag("statsd-endpoint", "Statsd endpoint").Default("10.244.11.2:8125").OverrideDefaultFromEnvar("STATSD_ENDPOINT").String()
+	statsdPrefix        = kingpin.Flag("statsd-prefix", "Statsd prefix").Default("mycf.").OverrideDefaultFromEnvar("STATSD_PREFIX").String()
+	username            = kingpin.Flag("username", "UAA username.").Default("").OverrideDefaultFromEnvar("USERNAME").String()
+	password            = kingpin.Flag("password", "UAA password.").Default("").OverrideDefaultFromEnvar("PASSWORD").String()
+	skipSSLValidation   = kingpin.Flag("skip-ssl-validation", "Please don't").Default("false").OverrideDefaultFromEnvar("SKIP_SSL_VALIDATION").Bool()
+	debug               = kingpin.Flag("debug", "Enable debug mode. This disables forwarding to statsd and prometheus and prints to stdout").Default("false").OverrideDefaultFromEnvar("DEBUG").Bool()
+	updateFrequency     = kingpin.Flag("update-frequency", "The time in seconds, that takes between each apps update call.").Default("300").OverrideDefaultFromEnvar("UPDATE_FREQUENCY").Int64()
+	metricTemplate      = kingpin.Flag("metric-template", "The template that will form a new metric namespace.").Default(senders.DefaultTemplate).OverrideDefaultFromEnvar("METRIC_TEMPLATE").String()
+	metricWhitelist     = kingpin.Flag("metric-whitelist", "Comma separated metric name prefixes to enable.").Default("").OverrideDefaultFromEnvar("METRIC_WHITELIST").String()
+	prometheusBindPort  = kingpin.Flag("prometheus-bind-port", "The port to bind to for prometheus metrics.").Default("8080").OverrideDefaultFromEnvar("PORT").Int()
+	prometheusMetricTTL = kingpin.Flag("prometheus-metric-ttl", "Time that a metric is kept in the prometheus exporter.").Default("60").OverrideDefaultFromEnvar("PROMETHEUS_METRIC_TTL").Int()
+	enableStatsd        = kingpin.Flag("enable-statsd", "Enable the statsd sender.").Default("true").OverrideDefaultFromEnvar("ENABLE_STATSD").Bool()
+	enablePrometheus    = kingpin.Flag("enable-prometheus", "Enable the prometheus sender.").Default("false").OverrideDefaultFromEnvar("ENABLE_PROMETHEUS").Bool()
 )
 
 func normalizePrefix(prefix string) string {
@@ -90,7 +91,10 @@ func main() {
 		if *enablePrometheus {
 			metricSenders = append(
 				metricSenders,
-				senders.NewPrometheusSender(prometheus.DefaultRegisterer),
+				senders.NewPrometheusSender(
+					prometheus.DefaultRegisterer,
+					prometheusMetricTTL*time.Second,
+				),
 			)
 		}
 

--- a/senders/metrics_expirer.go
+++ b/senders/metrics_expirer.go
@@ -1,0 +1,92 @@
+package senders
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mitchellh/hashstructure"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metricID struct {
+	Name   string
+	Labels prometheus.Labels
+}
+
+type metricActivity struct {
+	metricID  metricID
+	timestamp time.Time
+}
+
+type MetricsExpirer struct {
+	mtx            sync.Mutex
+	metricActivity map[uint64]metricActivity
+	callback       MetricsExpirerCallback
+	ttl            time.Duration
+
+	quit chan struct{}
+}
+
+type MetricsExpirerCallback func(name string, labels prometheus.Labels)
+
+func NewMetricsExpirer(
+	callback MetricsExpirerCallback,
+	ttl time.Duration,
+	frequency time.Duration,
+) *MetricsExpirer {
+
+	e := &MetricsExpirer{
+		metricActivity: map[uint64]metricActivity{},
+		callback:       callback,
+		ttl:            ttl,
+		quit:           make(chan struct{}),
+	}
+
+	ticker := time.NewTicker(frequency)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				e.expireMetrics()
+			case <-e.quit:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return e
+}
+
+func (s *MetricsExpirer) Stop() {
+	s.quit <- struct{}{}
+}
+
+func (s *MetricsExpirer) SeenMetric(name string, labels prometheus.Labels) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	id := metricID{
+		Name:   name,
+		Labels: labels,
+	}
+	h, _ := hashstructure.Hash(id, nil)
+	s.metricActivity[h] = metricActivity{
+		metricID:  id,
+		timestamp: time.Now(),
+	}
+}
+
+func (s *MetricsExpirer) expireMetrics() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	cutTime := time.Now().Add(-1 * s.ttl)
+	for h, a := range s.metricActivity {
+		if cutTime.After(a.timestamp) {
+			id := a.metricID
+			s.callback(id.Name, id.Labels)
+			delete(s.metricActivity, h)
+		}
+	}
+}

--- a/senders/metrics_expirer_test.go
+++ b/senders/metrics_expirer_test.go
@@ -1,0 +1,69 @@
+package senders_test
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	. "github.com/alphagov/paas-metric-exporter/senders"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MetricsExpirer", func() {
+	var (
+		expirer        *MetricsExpirer
+		deletedMetrics map[string]prometheus.Labels
+	)
+
+	BeforeEach(func() {
+		deletedMetrics = map[string]prometheus.Labels{}
+		expirer = NewMetricsExpirer(
+			func(name string, labels prometheus.Labels) {
+				deletedMetrics[name] = labels
+			},
+			100*time.Millisecond,
+			50*time.Millisecond,
+		)
+	})
+
+	AfterEach(func() {
+		expirer.Stop()
+	})
+
+	It("does not expire metrics recently refreshed", func() {
+		Consistently(
+			func() map[string]prometheus.Labels {
+				expirer.SeenMetric("a_metric", prometheus.Labels{"label1": "val1"})
+				return deletedMetrics
+			},
+			500*time.Millisecond,
+			50*time.Millisecond,
+		).Should(
+			HaveLen(0),
+		)
+	})
+
+	It("expires old metrics", func() {
+		expirer.SeenMetric("a_metric", prometheus.Labels{"label1": "val1"})
+		expirer.SeenMetric("other_metric", prometheus.Labels{"label1": "val1"})
+		expirer.SeenMetric("other_metric", prometheus.Labels{"label2": "val2"})
+
+		Eventually(
+			func() map[string]prometheus.Labels {
+				expirer.SeenMetric("other_metric", prometheus.Labels{"label2": "val2"})
+				expirer.SeenMetric("and_other_metric", prometheus.Labels{})
+				return deletedMetrics
+			},
+			500*time.Millisecond,
+			50*time.Millisecond,
+		).Should(
+			And(
+				HaveLen(2),
+				HaveKeyWithValue("a_metric", prometheus.Labels{"label1": "val1"}),
+				HaveKeyWithValue("other_metric", prometheus.Labels{"label1": "val1"}),
+			),
+		)
+	})
+})

--- a/senders/prometheus.go
+++ b/senders/prometheus.go
@@ -13,11 +13,12 @@ type PrometheusSender struct {
 	counterVecs   map[string]prometheus.CounterVec
 	gaugeVecs     map[string]prometheus.GaugeVec
 	histogramVecs map[string]prometheus.HistogramVec
+	registerer    prometheus.Registerer
 }
 
 var _ metrics.Sender = &PrometheusSender{}
 
-func NewPrometheusSender() *PrometheusSender {
+func NewPrometheusSender(registerer prometheus.Registerer) *PrometheusSender {
 	presenter := presenters.NewSnakeCasePresenter()
 
 	counterVecs := make(map[string]prometheus.CounterVec)
@@ -29,6 +30,7 @@ func NewPrometheusSender() *PrometheusSender {
 		counterVecs,
 		gaugeVecs,
 		histogramVecs,
+		registerer,
 	}
 }
 
@@ -42,7 +44,7 @@ func (s *PrometheusSender) Gauge(metric metrics.GaugeMetric) error {
 		options := prometheus.GaugeOpts{Name: name, Help: " "}
 		gaugeVec = *prometheus.NewGaugeVec(options, labelNames)
 
-		prometheus.MustRegister(gaugeVec)
+		s.registerer.MustRegister(gaugeVec)
 		s.gaugeVecs[name] = gaugeVec
 	}
 
@@ -64,7 +66,7 @@ func (s *PrometheusSender) Incr(metric metrics.CounterMetric) error {
 		options := prometheus.CounterOpts{Name: name, Help: " "}
 		counterVec = *prometheus.NewCounterVec(options, labelNames)
 
-		prometheus.MustRegister(counterVec)
+		s.registerer.MustRegister(counterVec)
 		s.counterVecs[name] = counterVec
 	}
 
@@ -86,7 +88,7 @@ func (s *PrometheusSender) PrecisionTiming(metric metrics.PrecisionTimingMetric)
 		options := prometheus.HistogramOpts{Name: name, Help: " "}
 		histogramVec = *prometheus.NewHistogramVec(options, labelNames)
 
-		prometheus.MustRegister(histogramVec)
+		s.registerer.MustRegister(histogramVec)
 		s.histogramVecs[name] = histogramVec
 	}
 

--- a/vendor/github.com/mitchellh/hashstructure/LICENSE
+++ b/vendor/github.com/mitchellh/hashstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/hashstructure/README.md
+++ b/vendor/github.com/mitchellh/hashstructure/README.md
@@ -1,0 +1,65 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+  
+  * Optionally hash the output of `.String()` on structs that implement fmt.Stringer,
+    allowing effective hashing of time.Time
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure.go
@@ -1,0 +1,358 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+)
+
+// ErrNotStringer is returned when there's an error with hash:"string"
+type ErrNotStringer struct {
+	Field string
+}
+
+// Error implements error for ErrNotStringer
+func (ens *ErrNotStringer) Error() string {
+	return fmt.Sprintf("hashstructure: %s has hash:\"string\" set, but does not implement fmt.Stringer", ens.Field)
+}
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+}
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values. The same *HashOptions value cannot be used
+// concurrently. None of the values within a *HashOptions struct are
+// safe to read/write while hashing is being done.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+//   * "string" - The field will be hashed as a string, only works when the
+//                field implements fmt.Stringer
+//
+func Hash(v interface{}, opts *HashOptions) (uint64, error) {
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		h:       opts.Hasher,
+		tag:     opts.TagName,
+		zeronil: opts.ZeroNil,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	h       hash.Hash64
+	tag     string
+	zeronil bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		parent := v.Interface()
+		var include Includable
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if innerV := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				// if string is set, use the string value
+				if tag == "string" {
+					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
+						innerV = reflect.ValueOf(impl.String())
+					} else {
+						return 0, &ErrNotStringer{
+							Field: v.Type().Field(i).Name,
+						}
+					}
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, innerV)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(innerV, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure_examples_test.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure_examples_test.go
@@ -1,0 +1,32 @@
+package hashstructure
+
+import (
+	"fmt"
+)
+
+func ExampleHash() {
+	type ComplexStruct struct {
+		Name     string
+		Age      uint
+		Metadata map[string]interface{}
+	}
+
+	v := ComplexStruct{
+		Name: "mitchellh",
+		Age:  64,
+		Metadata: map[string]interface{}{
+			"car":      true,
+			"location": "California",
+			"siblings": []string{"Bob", "John"},
+		},
+	}
+
+	hash, err := Hash(v, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%d", hash)
+	// Output:
+	// 6691276962590150517
+}

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure_test.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure_test.go
@@ -1,0 +1,565 @@
+package hashstructure
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestHash_identity(t *testing.T) {
+	cases := []interface{}{
+		nil,
+		"foo",
+		42,
+		true,
+		false,
+		[]string{"foo", "bar"},
+		[]interface{}{1, nil, "foo"},
+		map[string]string{"foo": "bar"},
+		map[interface{}]string{"foo": "bar"},
+		map[interface{}]interface{}{"foo": "bar", "bar": 0},
+		struct {
+			Foo string
+			Bar []interface{}
+		}{
+			Foo: "foo",
+			Bar: []interface{}{nil, nil, nil},
+		},
+		&struct {
+			Foo string
+			Bar []interface{}
+		}{
+			Foo: "foo",
+			Bar: []interface{}{nil, nil, nil},
+		},
+	}
+
+	for _, tc := range cases {
+		// We run the test 100 times to try to tease out variability
+		// in the runtime in terms of ordering.
+		valuelist := make([]uint64, 100)
+		for i, _ := range valuelist {
+			v, err := Hash(tc, nil)
+			if err != nil {
+				t.Fatalf("Error: %s\n\n%#v", err, tc)
+			}
+
+			valuelist[i] = v
+		}
+
+		// Zero is always wrong
+		if valuelist[0] == 0 {
+			t.Fatalf("zero hash: %#v", tc)
+		}
+
+		// Make sure all the values match
+		t.Logf("%#v: %d", tc, valuelist[0])
+		for i := 1; i < len(valuelist); i++ {
+			if valuelist[i] != valuelist[0] {
+				t.Fatalf("non-matching: %d, %d\n\n%#v", i, 0, tc)
+			}
+		}
+	}
+}
+
+func TestHash_equal(t *testing.T) {
+	type testFoo struct{ Name string }
+	type testBar struct{ Name string }
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			map[string]string{"foo": "bar"},
+			map[interface{}]string{"foo": "bar"},
+			true,
+		},
+
+		{
+			map[string]interface{}{"1": "1"},
+			map[string]interface{}{"1": "1", "2": "2"},
+			false,
+		},
+
+		{
+			struct{ Fname, Lname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"bar", "foo"},
+			false,
+		},
+
+		{
+			struct{ Lname, Fname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"foo", "bar"},
+			false,
+		},
+
+		{
+			struct{ Lname, Fname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"bar", "foo"},
+			true,
+		},
+
+		{
+			testFoo{"foo"},
+			testBar{"foo"},
+			false,
+		},
+
+		{
+			struct {
+				Foo        string
+				unexported string
+			}{
+				Foo:        "bar",
+				unexported: "baz",
+			},
+			struct {
+				Foo        string
+				unexported string
+			}{
+				Foo:        "bar",
+				unexported: "bang",
+			},
+			true,
+		},
+
+		{
+			struct {
+				testFoo
+				Foo string
+			}{
+				Foo:     "bar",
+				testFoo: testFoo{Name: "baz"},
+			},
+			struct {
+				testFoo
+				Foo string
+			}{
+				Foo: "bar",
+			},
+			true,
+		},
+
+		{
+			struct {
+				Foo string
+			}{
+				Foo: "bar",
+			},
+			struct {
+				testFoo
+				Foo string
+			}{
+				Foo: "bar",
+			},
+			true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Logf("Hashing: %#v", tc.One)
+			one, err := Hash(tc.One, nil)
+			t.Logf("Result: %d", one)
+			if err != nil {
+				t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+			}
+			t.Logf("Hashing: %#v", tc.Two)
+			two, err := Hash(tc.Two, nil)
+			t.Logf("Result: %d", two)
+			if err != nil {
+				t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+			}
+
+			// Zero is always wrong
+			if one == 0 {
+				t.Fatalf("zero hash: %#v", tc.One)
+			}
+
+			// Compare
+			if (one == two) != tc.Match {
+				t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+			}
+		})
+	}
+}
+
+func TestHash_equalIgnore(t *testing.T) {
+	type Test1 struct {
+		Name string
+		UUID string `hash:"ignore"`
+	}
+
+	type Test2 struct {
+		Name string
+		UUID string `hash:"-"`
+	}
+
+	type TestTime struct {
+		Name string
+		Time time.Time `hash:"string"`
+	}
+
+	type TestTime2 struct {
+		Name string
+		Time time.Time
+	}
+
+	now := time.Now()
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "bar"},
+			true,
+		},
+
+		{
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "foo"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "bar"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "foo"},
+			true,
+		},
+		{
+			TestTime{Name: "foo", Time: now},
+			TestTime{Name: "foo", Time: time.Time{}},
+			false,
+		},
+		{
+			TestTime{Name: "foo", Time: now},
+			TestTime{Name: "foo", Time: now},
+			true,
+		},
+		{
+			TestTime2{Name: "foo", Time: now},
+			TestTime2{Name: "foo", Time: time.Time{}},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_stringTagError(t *testing.T) {
+	type Test1 struct {
+		Name        string
+		BrokenField string `hash:"string"`
+	}
+
+	type Test2 struct {
+		Name        string
+		BustedField int `hash:"string"`
+	}
+
+	type Test3 struct {
+		Name string
+		Time time.Time `hash:"string"`
+	}
+
+	cases := []struct {
+		Test  interface{}
+		Field string
+	}{
+		{
+			Test1{Name: "foo", BrokenField: "bar"},
+			"BrokenField",
+		},
+		{
+			Test2{Name: "foo", BustedField: 23},
+			"BustedField",
+		},
+		{
+			Test3{Name: "foo", Time: time.Now()},
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		_, err := Hash(tc.Test, nil)
+		if err != nil {
+			if ens, ok := err.(*ErrNotStringer); ok {
+				if ens.Field != tc.Field {
+					t.Fatalf("did not get expected field %#v: got %s wanted %s", tc.Test, ens.Field, tc.Field)
+				}
+			} else {
+				t.Fatalf("unknown error %#v: got %s", tc, err)
+			}
+		}
+	}
+}
+
+func TestHash_equalNil(t *testing.T) {
+	type Test struct {
+		Str   *string
+		Int   *int
+		Map   map[string]string
+		Slice []string
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		ZeroNil  bool
+		Match    bool
+	}{
+		{
+			Test{
+				Str:   nil,
+				Int:   nil,
+				Map:   nil,
+				Slice: nil,
+			},
+			Test{
+				Str:   new(string),
+				Int:   new(int),
+				Map:   make(map[string]string),
+				Slice: make([]string, 0),
+			},
+			true,
+			true,
+		},
+		{
+			Test{
+				Str:   nil,
+				Int:   nil,
+				Map:   nil,
+				Slice: nil,
+			},
+			Test{
+				Str:   new(string),
+				Int:   new(int),
+				Map:   make(map[string]string),
+				Slice: make([]string, 0),
+			},
+			false,
+			false,
+		},
+		{
+			nil,
+			0,
+			true,
+			true,
+		},
+		{
+			nil,
+			0,
+			false,
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, &HashOptions{ZeroNil: tc.ZeroNil})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, &HashOptions{ZeroNil: tc.ZeroNil})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_equalSet(t *testing.T) {
+	type Test struct {
+		Name    string
+		Friends []string `hash:"set"`
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			Test{Name: "foo", Friends: []string{"bar", "foo"}},
+			true,
+		},
+
+		{
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_includable(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludable{Value: "foo"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "bar"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_includableMap(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"bar": "baz"}},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+type testIncludable struct {
+	Value  string
+	Ignore string
+}
+
+func (t testIncludable) HashInclude(field string, v interface{}) (bool, error) {
+	return field != "Ignore", nil
+}
+
+type testIncludableMap struct {
+	Map map[string]string
+}
+
+func (t testIncludableMap) HashIncludeMap(field string, k, v interface{}) (bool, error) {
+	if field != "Map" {
+		return true, nil
+	}
+
+	if s, ok := k.(string); ok && s == "ignore" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/mitchellh/hashstructure/include.go
+++ b/vendor/github.com/mitchellh/hashstructure/include.go
@@ -1,0 +1,15 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}


### PR DESCRIPTION
What?
----

This project uses the prometheus go-client libraries to store the metrics
received from CF, and expose them as an endpoint.

The prometheus go client metrics vectors objects[1] like CounterVec,
GaugeVec and HistogramVec do not include logic to expire metrics, instead
they cache the values forever without any timeout.

This is causing us some trouble, as we are efectivelly caching for ever every
single metric that the service receives. Specifically:

 * An app that is restarted in other cells would get metrics reported
   from previous cells, despite not being running there anymore.
 * A deleted app would be reported all the time.
 * A renamed app would have duplicated (problem in blue-green deploys)
 * A scaled down app (e.g. 4 to 2 instances) will still report old instances.
 * etc.

As a short term workaround, we add logic to expire the metrics received
by this service after a given TTL when using prometheus.

See commits for details.

How to review
-------------

 - Code review
 - tests should pass

Dependencies
------------

There are a pair of support tickets about this that need updating.

Tell the tenants to upgrade once merged.

Who?
----

Not me