### PR TITLE
[#159142216] Fix prometheus-metric-ttl type conversion

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 				metricSenders,
 				senders.NewPrometheusSender(
 					prometheus.DefaultRegisterer,
-					prometheusMetricTTL*time.Second,
+					time.Duration(*prometheusMetricTTL)*time.Second,
 				),
 			)
 		}


### PR DESCRIPTION
What?
-----

Fix a bug introduced in #30

it is a *int and we need to convert it to time.Duration to
multiply it with time.Second.

review
-------

Code review

To test:

```
PORT=8080 \
ENABLE_PROMETHEUS=true \
ENABLE_STATSD=false \
API_ENDPOINT=$(cf api | awk '/api endpoint/ {print $3}') \
USERNAME=... \
PASSWORD=... \
go run main.go
```
Check the prometheus exported metrics with:  `curl -qs http://localhost:8080/metrics`


Who?
---

Not me.