### PR TITLE
Fix link to documentation on Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following metrics will be exported for every application instance.
 
 ## Getting Started
 
-Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/#metrics) for instructions on how to set up the metrics exporter app. Information on the configuration options are in the following table.
+Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/monitoring_apps.html#metrics) for instructions on how to set up the metrics exporter app. Information on the configuration options are in the following table.
 
 |Configuration Option|Application Flag|Environment Variable|Notes|
 |:---|:---|:---|:---|


### PR DESCRIPTION
# What

The link to the metrics section was pointed at the main page, instead of the metrics bit.

# Review

* Follow the link

# Who can review

Anyone