### PR TITLE
[#161717942] Fix deprecation warning from manifests

### DIFF
--- a/manifest-prometheus.yml
+++ b/manifest-prometheus.yml
@@ -3,7 +3,8 @@ applications:
 - name: metric-exporter
   memory: 100M
   instances: 1
-  buildpack: go_buildpack
+  buildpacks:
+    - go_buildpack
   env:
     GOPACKAGENAME: github.com/alphagov/paas-metric-exporter
     ENABLE_STATSD: false

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,8 @@ applications:
 - name: metric-exporter
   memory: 100M
   instances: 1
-  buildpack: go_buildpack
+  buildpacks:
+    - go_buildpack
   env:
     GOPACKAGENAME: github.com/alphagov/paas-metric-exporter
   health-check-type: none


### PR DESCRIPTION
> Deprecation warning: Use of 'buildpack' attribute in manifest is
> deprecated in favor of 'buildpacks'. Please see
> http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated
> for alternatives and other app manifest deprecations. This feature will
> be removed in the future.