### PR TITLE
[#163362196] - Mark Prometheus support as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This application consumes container metrics off the Cloud Foundry Doppler daemon
 
 The application will get metrics for all apps that the user has access to.
 
+To use paas-metric-exporter with GOV.UK PaaS, see [the documentation](https://docs.cloud.service.gov.uk/monitoring_apps.html#metrics-exporter-app-with-statsd).
+
+:warning: Prometheus support in paas-metric-exporter is deprecated. Please use [alphagov/paas-prometheus-exporter](https://github.com/alphagov/paas-prometheus-exporter) instead.
+
+## History
+
 The application is based on [`pivotal-cf/graphite-nozzle`](https://github.com/pivotal-cf/graphite-nozzle).
 
 ## Available metrics


### PR DESCRIPTION
This should make it a little more clear what this codebase is for (StatsD, not Prometheus).

Also adds a link to the docs.

See also https://github.com/alphagov/paas-prometheus-exporter/pull/23