### PR TITLE
Upgrade PaaS stack to cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,7 @@ applications:
 - name: metric-exporter
   memory: 100M
   instances: 1
+  stack: cflinuxfs3
   buildpacks:
     - go_buildpack
   env:


### PR DESCRIPTION
- This is the Ubuntu Bionic stack as cflinuxfs2 (Ubuntu Trusty) goes out
  of support soon.